### PR TITLE
fix: Resolve missing No Agenda data due to variable inconsistency

### DIFF
--- a/client/lib/documentStore.ts
+++ b/client/lib/documentStore.ts
@@ -125,23 +125,9 @@ export const useDocumentStore = create<DocumentStore>((set, get) => ({
   loadGoogleSheetsData: async () => {
     set({ isLoadingGoogleSheets: true, googleSheetsError: null });
     try {
-      const { documents: googleSheetsDocuments, total } =
-        await fetchDocumentsFromGoogleSheets();
-      const documents: Document[] = googleSheetsDocuments
-        .map((doc, index) => ({
-          id: `${doc.agendaNumber}-${index}`,
-          agendaNo: doc.agendaNumber,
-          sender: doc.sender,
-          perihal: doc.perihal,
-          position: doc.currentLocation || "Unknown",
-          createdAt: doc.createdAt,
-          expeditionHistory: [],
-          currentRecipient: doc.currentLocation,
-          isFromGoogleSheets: true,
-          lastExpedition: doc.lastExpedition,
-          signature: doc.signature,
-        }))
-        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      const { documents, total } = await fetchDocumentsFromGoogleSheets();
+      // The service now returns fully processed Document objects, so no mapping is needed.
+      // The sorting is also already done in the service.
       set({
         documents,
         isLoadingGoogleSheets: false,


### PR DESCRIPTION
This commit provides a critical fix for the issue where the `No Agenda` data was not appearing in the UI.

The root cause was a variable name inconsistency in the `documentStore`. The data service provided the document objects with the property `agendaNo`, but the store was attempting to map this data using the old property name, `agendaNumber`. This resulted in the `agendaNo` field being `undefined` in the application's state.

The incorrect and redundant `.map()` call in the `documentStore` has been removed. The store now correctly uses the fully-formed `Document` objects provided directly by the data service.

This resolves the bug and ensures the `No Agenda` data is displayed correctly.