### PR TITLE
fix: Refactor data fetching to fix blank page issue

### DIFF
--- a/client/lib/utils.ts
+++ b/client/lib/utils.ts
@@ -4,3 +4,32 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+// Convert signature canvas to JPEG
+export function convertSignatureToLowResJPEG(
+  signatureDataUrl: string,
+): Promise<string> {
+  return new Promise((resolve) => {
+    try {
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return resolve(signatureDataUrl);
+
+      canvas.width = 200;
+      canvas.height = 100;
+
+      const img = new Image();
+      img.onload = () => {
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        resolve(canvas.toDataURL("image/jpeg", 0.3));
+      };
+      img.onerror = () => {
+        resolve(signatureDataUrl);
+      };
+      img.src = signatureDataUrl;
+    } catch (error) {
+      console.error("Error converting signature:", error);
+      resolve(signatureDataUrl);
+    }
+  });
+}

--- a/client/pages/Expedition.tsx
+++ b/client/pages/Expedition.tsx
@@ -3,10 +3,7 @@ import { Search, X, Save, Trash2 } from "lucide-react";
 import { useDocumentStore, Document } from "../lib/documentStore";
 import { useToast } from "../lib/toastContext";
 import { cn } from "../lib/utils";
-import {
-  updateSpreadsheetWithExpedition,
-  convertSignatureToLowResJPEG,
-} from "../lib/googleSheetsService";
+import { convertSignatureToLowResJPEG } from "../lib/utils";
 import { useNavigate, useLocation } from "react-router-dom";
 import ConfirmDialog from "../components/ConfirmDialog";
 import { useNavigationGuard } from "../App";
@@ -283,17 +280,24 @@ const Expedition: React.FC = () => {
         }`;
 
         // Update expedition data in Google Sheets
-        const success = await updateSpreadsheetWithExpedition(
-          document.agendaNo,
-          expeditionDetails, // lastExpedition
-          recipient.trim(), // currentLocation
-          "Accepted", // status
-          processedSignature,
-        );
+        const response = await fetch("/api/update-sheet", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            agendaNo: document.agendaNo,
+            lastExpedition: expeditionDetails,
+            currentLocation: recipient.trim(),
+            status: "Accepted",
+            signature: processedSignature,
+          }),
+        });
 
-        if (!success) {
+        if (!response.ok) {
+          const errorData = await response.json();
           showToast(
-            `Failed to update expedition data for ${document.agendaNo}`,
+            `Failed to update expedition data for ${document.agendaNo}: ${errorData.message}`,
             "error",
           );
           return;


### PR DESCRIPTION
I've refactored the data fetching logic to fix an issue where the application would display a blank page. The problem was caused by fetching data directly from a public Google Sheet URL on the frontend, which is an unreliable method that was likely failing in the production environment.

To create a more robust, backend-driven solution, I made the following changes:

1.  **New API Endpoint:** I created a new `/api/documents` endpoint on the Express server. This endpoint uses the authenticated `googleapis` client to fetch data from the Google Sheet, ensuring a more reliable connection.
2.  **Frontend Refactoring:** I updated `documentStore.ts` on the frontend to call the new `/api/documents` endpoint instead of the public URL. I also updated the data types to handle the JSON response correctly.
3.  **Refactor Expedition Page:** I refactored the `Expedition.tsx` page to use a backend API endpoint (`/api/update-sheet`) instead of directly calling a function from the now-removed `googleSheetsService.ts`. I also moved the `convertSignatureToLowResJPEG` utility function to `client/lib/utils.ts`.
4.  **Removed Unused Code:** I removed the `googleSheetsService.ts` file, as it contained the old, unreliable fetching logic and is no longer needed.

These changes should resolve the blank page issue and make the application more stable.