### PR TITLE
Fix: Resolve blank page issue by unifying Document type

### DIFF
--- a/client/components/DocumentDetail.tsx
+++ b/client/components/DocumentDetail.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { X, Calendar, User, FileText, Clock, MapPin } from "lucide-react";
-import { format } from "date-fns";
+import { X } from "lucide-react";
+import { format, parseISO } from "date-fns";
 import { id } from "date-fns/locale";
-import { Document } from "../lib/documentStore";
+import { Document } from "../lib/types";
 
 interface DocumentDetailProps {
   document: Document | null;

--- a/client/lib/documentStore.ts
+++ b/client/lib/documentStore.ts
@@ -58,9 +58,7 @@ export const useDocumentStore = create<DocumentStore>((set, get) => ({
       documents: state.documents.map((doc) => {
         if (expedition.documentIds.includes(doc.id)) {
           const newExpeditionEntry = {
-            id: `exp-${Date.now()}-${doc.id}`,
-            date: expedition.date,
-            time: expedition.time,
+            timestamp: expedition.date,
             recipient: expedition.recipient,
             signature: expedition.signature,
             notes: expedition.notes,
@@ -98,7 +96,7 @@ export const useDocumentStore = create<DocumentStore>((set, get) => ({
         ...doc,
         createdAt: new Date(doc.createdAt),
         tanggalTerima: doc.tanggalTerima ? new Date(doc.tanggalTerima) : null,
-        expeditionHistory: doc.expeditionHistory.map((h: any) => ({
+        expeditionHistory: (doc.expeditionHistory || []).map((h: any) => ({
           ...h,
           timestamp: new Date(h.timestamp),
         })),

--- a/client/lib/types.ts
+++ b/client/lib/types.ts
@@ -1,25 +1,5 @@
 // This file will contain shared type definitions to avoid circular dependencies.
-export interface Document {
-  id: string;
-  agendaNo: string;
-  sender: string;
-  perihal: string; // Changed from subject to perihal
-  position: string;
-  createdAt: Date | string;
-  expeditionHistory: Array<{
-    timestamp: Date | string;
-    recipient: string;
-    signature?: string;
-    notes?: string;
-    details?: string;
-  }>;
-  currentRecipient?: string;
-  lastExpedition?: string;
-  signature?: string;
-  // New fields for the redesigned UI
-  tanggalTerima?: Date | string;
-  currentStatus?: string;
-}
+export type { Document, ExpeditionHistoryEntry } from '../../shared/api';
 
 export interface ExpeditionRecord {
   id: string;

--- a/client/pages/DocumentList.tsx
+++ b/client/pages/DocumentList.tsx
@@ -2,13 +2,13 @@ import React, { useState, useEffect } from "react";
 import {
   Search,
   FileText,
-  User,
   RefreshCw,
   AlertCircle,
   Database,
   Calendar,
 } from "lucide-react";
-import { useDocumentStore, Document } from "../lib/documentStore";
+import { useDocumentStore } from "../lib/documentStore";
+import { Document } from "../lib/types";
 import { format } from "date-fns";
 import { id } from "date-fns/locale";
 import { cn } from "../lib/utils";

--- a/client/pages/Expedition.tsx
+++ b/client/pages/Expedition.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { Search, X, Save, Trash2 } from "lucide-react";
-import { useDocumentStore, Document } from "../lib/documentStore";
+import { useDocumentStore } from "../lib/documentStore";
+import { Document } from "../lib/types";
 import { useToast } from "../lib/toastContext";
 import { cn } from "../lib/utils";
 import { convertSignatureToLowResJPEG } from "../lib/utils";

--- a/netlify/functions/google-sheets.ts
+++ b/netlify/functions/google-sheets.ts
@@ -1,22 +1,13 @@
 import { Handler } from '@netlify/functions';
 import { google } from 'googleapis';
 import { GOOGLE_SHEETS_CONFIG } from '../../config/google-sheets.config';
+import { Document } from '../../shared/api';
 
 // Service account credentials
 const SERVICE_ACCOUNT_CREDENTIALS = GOOGLE_SHEETS_CONFIG.SERVICE_ACCOUNT;
 
 const SPREADSHEET_ID = GOOGLE_SHEETS_CONFIG.SPREADSHEET_ID;
 const SHEET_NAME = GOOGLE_SHEETS_CONFIG.SHEET_NAME;
-
-interface Document {
-  id: string;
-  agendaNo: string;
-  sender: string;
-  subject: string;
-  position: string;
-  createdAt: string;
-  expeditionHistory: any[];
-}
 
 export const handler: Handler = async (event) => {
   // Enable CORS
@@ -59,13 +50,13 @@ export const handler: Handler = async (event) => {
     const documents: Document[] = rows.map((row, index) => {
       const agendaNo = row[0] || `AGENDA-${String(index + 1).padStart(3, '0')}`; // Column A
       const sender = `${row[3] || ''} ${row[4] || ''}`.trim() || 'Unknown Sender'; // Columns D and E
-      const subject = `${row[4] || ''} ${row[5] || ''} ${row[6] || ''}`.trim() || 'No Subject'; // Columns E, F, G
+      const perihal = `${row[4] || ''} ${row[5] || ''} ${row[6] || ''}`.trim() || 'No Subject'; // Columns E, F, G
       
       return {
         id: `gs-${index + 1}`,
         agendaNo: agendaNo,
         sender: sender,
-        subject: subject,
+        perihal: perihal,
         position: 'Pending', // Default position
         createdAt: new Date().toISOString(),
         expeditionHistory: [],

--- a/server/routes/documents.ts
+++ b/server/routes/documents.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from "express";
 import { google } from "googleapis";
-import { Document } from "@shared/api";
+import { Document } from "../../shared/api";
 
 const SPREADSHEET_ID = "19FgFYyhgnMmWIVIHK-1cOmgrQIik_j4mqUnLz5aArR4";
 const SHEET_NAME = "SURATMASUK";
@@ -19,28 +19,6 @@ async function getGoogleSheetsClient() {
 
   const sheets = google.sheets({ version: "v4", auth });
   return sheets;
-}
-
-function parseCSV(csvText: string): string[][] {
-    const lines = csvText.split('\n');
-    return lines.map(line => {
-        const cells = [];
-        let current = '';
-        let inQuotes = false;
-        for (let i = 0; i < line.length; i++) {
-            const char = line[i];
-            if (char === '"') {
-                inQuotes = !inQuotes;
-            } else if (char === ',' && !inQuotes) {
-                cells.push(current.trim().replace(/^"|"$/g, ''));
-                current = '';
-            } else {
-                current += char;
-            }
-        }
-        cells.push(current.trim().replace(/^"|"$/g, ''));
-        return cells;
-    });
 }
 
 function convertRowToDocument(row: string[], index: number): Document | null {
@@ -155,7 +133,7 @@ export const handleGetDocuments: RequestHandler = async (req, res) => {
       }
     }
 
-    documents.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    documents.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
     res.json({ documents, total: documents.length });
 

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -4,6 +4,31 @@
  * and/or small pure JS functions that can be used on both client and server
  */
 
+export interface ExpeditionHistoryEntry {
+  timestamp: Date | string;
+  recipient: string;
+  signature?: string;
+  notes?: string;
+  details?: string;
+  order?: number;
+}
+
+export interface Document {
+  id: string;
+  agendaNo: string;
+  sender: string;
+  perihal: string;
+  position: string;
+  createdAt: Date | string;
+  expeditionHistory: ExpeditionHistoryEntry[];
+  currentRecipient?: string;
+  lastExpedition?: string;
+  signature?: string;
+  isFromGoogleSheets?: boolean;
+  tanggalTerima?: Date | string;
+  currentStatus?: string;
+}
+
 /**
  * Example response type for /api/demo
  */


### PR DESCRIPTION
This commit addresses a critical bug that caused a blank white page to be displayed on the production site. The root cause was a `TypeError` on the client-side, triggered by an inconsistency between the data structure expected by the frontend and the one provided by the backend API.

Key changes:
- **Unified `Document` Type:** Consolidated the `Document` type definition into a single source of truth in `shared/api.ts` to eliminate conflicts between the client, server, and Netlify functions.
- **Corrected Data Mapping:** Updated the Netlify function (`netlify/functions/google-sheets.ts`) to use the shared `Document` type and correctly map the `perihal` field (previously `subject`), resolving the direct cause of the client-side crash.
- **Improved Client-Side Resilience:** Added a defensive check in the client's data store (`client/lib/documentStore.ts`) to prevent crashes from malformed `expeditionHistory` data.
- **Fixed Type Errors:** Resolved numerous TypeScript errors across the codebase that resulted from the type consolidation, including incorrect imports, missing properties on created objects, and unsafe method calls on union types. This improves the overall stability and maintainability of the code.

All type checks and tests now pass, confirming the validity of the fix and ensuring no regressions were introduced.