### PR TITLE
Feat: Add diagnostic logging to backend documents route

### DIFF
--- a/server/routes/documents.ts
+++ b/server/routes/documents.ts
@@ -107,6 +107,14 @@ function convertRowToDocument(row: string[], index: number): Document | null {
 
 
 export const handleGetDocuments: RequestHandler = async (req, res) => {
+  // Diagnostic logging
+  console.log("Handling /api/documents request.");
+  if (process.env.GOOGLE_PRIVATE_KEY) {
+    console.log("GOOGLE_PRIVATE_KEY environment variable found.");
+  } else {
+    console.error("CRITICAL: GOOGLE_PRIVATE_KEY environment variable NOT FOUND.");
+  }
+
   try {
     const sheets = await getGoogleSheetsClient();
     const response = await sheets.spreadsheets.values.get({


### PR DESCRIPTION
This commit adds diagnostic logging to the `handleGetDocuments` function in `server/routes/documents.ts`.

The purpose of this logging is to help diagnose a "Failed to fetch documents" error that occurs in the production environment. The log will print a message to the Netlify function logs indicating whether the `GOOGLE_PRIVATE_KEY` environment variable was found at runtime.

This will help determine if the error is caused by a missing environment variable or another issue with the Google Sheets API authentication or permissions.