### PR TITLE
Fix: Improve backend error message for easier debugging

### DIFF
--- a/server/routes/documents.ts
+++ b/server/routes/documents.ts
@@ -147,6 +147,7 @@ export const handleGetDocuments: RequestHandler = async (req, res) => {
 
   } catch (error: any) {
     console.error("Error fetching documents from Google Sheets:", error);
-    res.status(500).json({ message: "Error fetching documents", error: error.message, details: error.stack });
+    const detailedMessage = "Failed to fetch documents from Google Sheets. This is a backend error. Please check the following: 1. Ensure the `GOOGLE_PRIVATE_KEY` environment variable is correctly set in your Vercel project settings. 2. Ensure the service account email (`dokpedisi-agent@docupr-467003.iam.gserviceaccount.com`) has 'Viewer' access to the Google Sheet. 3. Ensure the Google Sheets API is enabled in your Google Cloud project.";
+    res.status(500).json({ message: detailedMessage, error: error.message, details: error.stack });
   }
 };


### PR DESCRIPTION
This commit enhances the error message returned by the `/api/documents` endpoint when it fails to fetch data from Google Sheets.

Previously, the error was a generic "Failed to fetch documents". This has been updated to a much more descriptive message that includes a checklist for you to follow. This will display the likely causes of the error (missing/incorrect environment variable, incorrect Google Sheet permissions, disabled Google Sheets API) directly in the frontend UI, making it easier for you to diagnose and resolve the external configuration issue.